### PR TITLE
Fix overflow in HttpClient

### DIFF
--- a/src/Core/Http/HttpClient.cs
+++ b/src/Core/Http/HttpClient.cs
@@ -182,7 +182,7 @@ namespace NuGet
                                 targetStream.Write(buffer, 0, bytesRead);
 
                                 totalReadSoFar += bytesRead;
-                                OnProgressAvailable((totalReadSoFar * 100) / length);
+                                OnProgressAvailable((int)(((long)totalReadSoFar * 100) / length)); // avoid 32 bit overflow by calculating * 100 with 64 bit
                             }
                         }
                     }


### PR DESCRIPTION
If a nuget package is larger than 21,474,836 bytes (int.Max/100), NuGet is generating a negative download percentage completion, leading to a progress bar constantly resetting every 20Mo.